### PR TITLE
Update PacketPipeline.java

### DIFF
--- a/src/main/java/net/infstudio/goki/common/network/packet/PacketPipeline.java
+++ b/src/main/java/net/infstudio/goki/common/network/packet/PacketPipeline.java
@@ -133,9 +133,17 @@ public class PacketPipeline extends MessageToMessageCodec<FMLProxyPacket, GokiPa
 
     }
 
-    @SideOnly(Side.CLIENT)
     private EntityPlayer getPlayer(boolean isClient, ChannelHandlerContext ctx) {
-        return isClient ? Minecraft.getMinecraft().player : ((NetHandlerPlayServer) ctx.channel().attr(NetworkRegistry.NET_HANDLER).get()).player;
+        return isClient ? getPlayerClient(ctx) : getPlayerServer(ctx);
+    }
+    
+    @SideOnly(Side.CLIENT)
+    private EntityPlayer getPlayerClient(ChannelHandlerContext ctx) {
+        return Minecraft.getMinecraft().player;
+    }
+    
+    private EntityPlayer getPlayerServer(ChannelHandlerContext ctx) {
+        return ((NetHandlerPlayServer) ctx.channel().attr(NetworkRegistry.NET_HANDLER).get()).player;
     }
 
     public void sendToAll(GokiPacket message) {


### PR DESCRIPTION
fix crash on server side
remove SideOnly on method getPlayer
fork method getPlayer -> @SideOnly(Side.CLIENT) getPlayerClient(ChannelHandlerContext) & getPlayerServer(ChannelHandlerContext)